### PR TITLE
Use new DialectResolver API for SQLite dialect bean

### DIFF
--- a/suprice/src/main/java/com/suprice/suprice/configuracion/ConfiguracionAplicacion.java
+++ b/suprice/src/main/java/com/suprice/suprice/configuracion/ConfiguracionAplicacion.java
@@ -9,9 +9,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.sqlite.SQLiteDataSource;
+import org.springframework.data.jdbc.core.dialect.DialectResolver;
 import org.springframework.data.relational.core.dialect.Dialect;
-import org.springframework.data.relational.core.dialect.SqliteDialect;
+import org.sqlite.SQLiteDataSource;
 
 /**
  * Configuración general de beans reutilizables dentro de la aplicación.
@@ -34,21 +34,20 @@ public class ConfiguracionAplicacion {
         }
 
         /**
+         * Bean para indicar el dialecto SQLite a Spring Data JDBC.
+         * Evita el error "Cannot determine a dialect for JdbcTemplate".
+         */
+        @Bean
+        public Dialect jdbcDialect(JdbcTemplate plantillaSqlite) {
+            return DialectResolver.getDialect(plantillaSqlite);
+        }
+
+        /**
          * Proporciona una {@link JdbcTemplate} ligada al origen de datos SQLite.
          *
          * @param dataSource origen de datos primario.
          * @return plantilla JDBC lista para uso.
          */
-
-        /**
-         * Bean para indicar el dialecto SQLite a Spring Data JDBC.
-         * Evita el error "Cannot determine a dialect for JdbcTemplate".
-         */
-        @Bean
-        public Dialect jdbcDialect() {
-            return SqliteDialect.INSTANCE;
-        }
-
         @Bean
         public JdbcTemplate plantillaSqlite(DataSource dataSource) {
             return new JdbcTemplate(dataSource);

--- a/suprice/src/main/java/com/suprice/suprice/servicio/ServicioConsultaProductos.java
+++ b/suprice/src/main/java/com/suprice/suprice/servicio/ServicioConsultaProductos.java
@@ -23,7 +23,6 @@ import com.suprice.suprice.modelo.ExistenciaDetalleDTO;
 import com.suprice.suprice.modelo.PrecioProductoDTO;
 import com.suprice.suprice.modelo.ProductoConsultadoDTO;
 import com.suprice.suprice.modelo.SolicitudConsultaProducto;
-import com.suprice.suprice.modelo.TipoSistemaAspel;
 import com.suprice.suprice.util.UtilidadesImpuestos;
 import com.suprice.suprice.util.UtilidadesRutas;
 


### PR DESCRIPTION
## Summary
- update the SQLite dialect bean to use the non-deprecated `org.springframework.data.jdbc.core.dialect.DialectResolver`

## Testing
- mvn -DskipTests compile

------
https://chatgpt.com/codex/tasks/task_e_68dc4e20f60c832d8ac1823ebe443575