### PR TITLE
Configure Spring Data dialect for SQLite

### DIFF
--- a/suprice/src/main/java/com/suprice/suprice/configuracion/ConfiguracionSqliteDialect.java
+++ b/suprice/src/main/java/com/suprice/suprice/configuracion/ConfiguracionSqliteDialect.java
@@ -1,0 +1,18 @@
+package com.suprice.suprice.configuracion;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.relational.core.dialect.Dialect;
+import org.springframework.data.relational.core.dialect.HsqlDbDialect;
+
+@Configuration
+public class ConfiguracionSqliteDialect {
+
+    @Bean
+    @ConditionalOnMissingBean(Dialect.class)
+    @SuppressWarnings("removal")
+    public Dialect sqliteDialect() {
+        return HsqlDbDialect.INSTANCE;
+    }
+}


### PR DESCRIPTION
## Summary
- provide a Spring configuration bean that supplies an explicit dialect when the application runs against SQLite
- suppress the pending removal warning on the dialect singleton used for compatibility

## Testing
- mvn test

------
https://chatgpt.com/codex/tasks/task_e_68dc6ae7ca74832d97e908bb3966142f