### PR TITLE
Improve frontend error handling when backend is offline

### DIFF
--- a/suprice/README.md
+++ b/suprice/README.md
@@ -221,6 +221,8 @@ mvn spring-boot:run
 ```
 Esto levanta el backend en `http://localhost:8080` y el frontend integrado de Hilla. Para desarrollo frontend autónomo puedes ejecutar `npm run dev` en otra terminal.
 
+> 💡 **Importante:** el frontend en modo desarrollo utiliza un proxy hacia `http://localhost:8080`. Si el backend no está en ejecución, las peticiones a `/api/...` devolverán errores 500 o `ECONNREFUSED`. Asegúrate de mantener `mvn spring-boot:run` activo mientras pruebas la interfaz con `npm run dev`.
+
 ## Uso de la aplicación
 1. Accede a `http://localhost:8080` y autentícate con un usuario válido (el administrador inicial es `admin` / `]mYMI&Rep711`, se recomienda cambiarlo).
 2. Selecciona el sistema (SAE o Caja), luego la versión detectada y la empresa.

--- a/suprice/src/main/frontend/main.tsx
+++ b/suprice/src/main/frontend/main.tsx
@@ -6,16 +6,22 @@ import LoginVista from './views/LoginVista';
 import PrincipalVista from './views/PrincipalVista';
 import AdminUsuariosVista from './views/AdminUsuariosVista';
 import { SesionContexto, UsuarioSesion } from './componentes/ContextoSesion';
+import { obtenerMensajeDesdeError } from './utilidades/mensajesError';
 
 const consultarSesionActual = async (): Promise<UsuarioSesion | undefined> => {
-  const respuesta = await fetch('/api/autenticacion/usuario-actual', {
-    credentials: 'include'
-  });
-  if (!respuesta.ok) {
+  try {
+    const respuesta = await fetch('/api/autenticacion/usuario-actual', {
+      credentials: 'include'
+    });
+    if (!respuesta.ok) {
+      return undefined;
+    }
+    const datos = await respuesta.json();
+    return datos ?? undefined;
+  } catch (error) {
+    console.warn(obtenerMensajeDesdeError(error, 'No se pudo consultar la sesión actual.'));
     return undefined;
   }
-  const datos = await respuesta.json();
-  return datos ?? undefined;
 };
 
 const App = () => {

--- a/suprice/src/main/frontend/utilidades/mensajesError.ts
+++ b/suprice/src/main/frontend/utilidades/mensajesError.ts
@@ -1,0 +1,33 @@
+export const MENSAJE_ERROR_CONEXION =
+  'No fue posible conectar con el servidor. Verifique que el servicio de backend esté en ejecución.';
+
+export const obtenerMensajeDesdeError = (error: unknown, mensajePorDefecto: string): string => {
+  if (error instanceof TypeError) {
+    return MENSAJE_ERROR_CONEXION;
+  }
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+  return mensajePorDefecto;
+};
+
+export const obtenerMensajeDesdeRespuesta = async (
+  respuesta: Response,
+  mensajePorDefecto: string
+): Promise<string> => {
+  if (respuesta.status >= 500) {
+    return MENSAJE_ERROR_CONEXION;
+  }
+  try {
+    const datos = await respuesta.clone().json();
+    if (datos && typeof datos === 'object' && 'mensaje' in datos) {
+      const mensaje = (datos as { mensaje?: unknown }).mensaje;
+      if (typeof mensaje === 'string' && mensaje.trim().length > 0) {
+        return mensaje;
+      }
+    }
+  } catch (error) {
+    console.warn('No fue posible interpretar la respuesta del servidor', error);
+  }
+  return mensajePorDefecto;
+};

--- a/suprice/src/main/frontend/views/LoginVista.tsx
+++ b/suprice/src/main/frontend/views/LoginVista.tsx
@@ -5,6 +5,7 @@ import { Notification } from '@vaadin/react-components/Notification.js';
 import { useContext, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { SesionContexto } from '../componentes/ContextoSesion';
+import { MENSAJE_ERROR_CONEXION, obtenerMensajeDesdeError, obtenerMensajeDesdeRespuesta } from '../utilidades/mensajesError';
 
 const LoginVista = () => {
   const { actualizarUsuario, usuario } = useContext(SesionContexto);
@@ -13,21 +14,31 @@ const LoginVista = () => {
   const manejarLogin = async (evento: CustomEvent<{ username: string; password: string }>) => {
     evento.preventDefault();
     const { username, password } = evento.detail;
-    const respuesta = await fetch('/api/autenticacion/iniciar', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      credentials: 'include',
-      body: JSON.stringify({ nombreUsuario: username, contrasena: password })
-    });
-    if (respuesta.ok) {
-      const datos = await respuesta.json();
-      actualizarUsuario(datos);
-      navigate('/principal');
-    } else {
-      const error = await respuesta.json().catch(() => ({ mensaje: 'No fue posible iniciar sesión' }));
-      Notification.show(error.mensaje ?? 'Credenciales incorrectas', { position: 'bottom-center', duration: 3000 });
+    try {
+      const respuesta = await fetch('/api/autenticacion/iniciar', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        credentials: 'include',
+        body: JSON.stringify({ nombreUsuario: username, contrasena: password })
+      });
+      if (respuesta.ok) {
+        const datos = await respuesta.json();
+        actualizarUsuario(datos);
+        navigate('/principal');
+        return;
+      }
+      const mensaje = await obtenerMensajeDesdeRespuesta(
+        respuesta,
+        respuesta.status >= 500 ? MENSAJE_ERROR_CONEXION : 'Credenciales incorrectas'
+      );
+      Notification.show(mensaje, { position: 'bottom-center', duration: 3000 });
+    } catch (error) {
+      Notification.show(obtenerMensajeDesdeError(error, 'No fue posible iniciar sesión'), {
+        position: 'bottom-center',
+        duration: 3000
+      });
     }
   };
 


### PR DESCRIPTION
## Summary
- add a shared utility to surface connection errors from fetch requests
- harden login, administration, and product views against backend outages with clearer notifications
- document the need to keep the Spring Boot backend running during Vite development

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc6f32a440832db582b15a8c9fdd61